### PR TITLE
Make days runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A project to get you started solving [Advent of Code](https://adventofcode.com/)
 
 ## Architecture
 
-The `Main` method in `App` will execute the code for a given day based on input in `src/main/resources/day[number].txt`
+Each day should extend the parent `Day` class, and initialise `Day.currentDay` with an instance of the day using a static initializer block. `Day` has a main method which will execute the code for the current day based on input in `src/main/resources/day[number].txt`
 
-The given `Day` class will process the input and return a result, which `App` will print to `stdout`.
+Running your child class will load the puzzle input and print the results of `part1()` and `part2()` to `stdout`.
 
 ## Assumptions
 
@@ -21,20 +21,20 @@ The shell for day 1 is already there. These are the steps to add day 2, etc. For
 
 ### Part 1
 
-1. Create `aoc.day02.Day02.java implements Day`
-1. Add a line to the static initialization block in `App.java` to add your nwe `Day` implementation: `DAYS.put(2, new Day02())`
-1. Create `Day02Test.java` and use the sample input/output from adventofcode.com/2019/day/2 to write tests (they will initially fail).
+1. Create `aoc.day02.Day02.java extends Day`
+1. Create a static initialization block in `Day02.java` to set your new `Day` child class: `static {currentDay = new Day02();}`
+1. Create `Day02Test.java` and use the sample input/output from https://adventofcode.com/2019/day/2 to write tests (they will initially fail).
 1. Implement `Day02.part1()` until the tests pass (Test Driven Development!). You can run `./gradlew --continuous check` to have the tests run every time you save your code.
-1. When the example input passes, get your solution from adventofcode.com/2019/day/2/input and save it as `src/main/resources/day02.txt`
+1. When the example input passes, get your unique puzzle input from https://adventofcode.com/2019/day/2/input and save it as `src/main/resources/day02.txt`
 1. Run `./gradlew clean build install && ./build/install/advent-of-code/bin/advent-of-code 2` to get your output.
     - Notice the day number ("2") is passed to the start script as an argument.
-1. Check your solution on adventofcode.com!
+1. Check your solution on https://adventofcode.com!
 
 ### Part 2
 
-1. Add new tests for part 2 to `Day02Test.java` using the sample input/output from adventofcode.com/2019/day/2
+1. Add new tests for part 2 to `Day02Test.java` using the sample input/output from https://adventofcode.com/2019/day/2
 1. Implement `Day02.part2()` until the tests pass.
 1. When the example input passes, run `./gradlew clean build install && ./build/install/advent-of-code/bin/advent-of-code 2 2` to get your output.
     - Notice the second argument to the script is the part number. It defaults to 1, so now you have to pass it as 2.
-1. Check your solution on adventofcode.com!
+1. Check your solution on https://adventofcode.com!
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.reflections:reflections:0.10.2")
     // Use JUnit Jupiter for testing.
     testImplementation(libs.junit.jupiter)
 

--- a/src/main/java/aoc/App.java
+++ b/src/main/java/aoc/App.java
@@ -5,13 +5,11 @@ package aoc;
 
 import aoc.day01.Day01;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.UncheckedIOException;
+import java.io.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
 
@@ -27,9 +25,13 @@ public class App {
     private static List<String> loadInput(int day){
         String fileName = String.format("day%02d.txt", day);
 
-        try(BufferedReader r = new BufferedReader(new InputStreamReader(ClassLoader.getSystemResourceAsStream(fileName)))){
+        InputStream inputForDay = ClassLoader.getSystemResourceAsStream(fileName);
+        if (Objects.isNull(inputForDay)) {
+            throw new IllegalArgumentException("Can’t find data for day using filename: " + fileName + ". Did you forget to put the file in the resources directory?");
+        }
+        try (BufferedReader r = new BufferedReader(new InputStreamReader(inputForDay))) {
             return r.lines().collect(toList());
-        } catch(IOException e){
+        } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }

--- a/src/main/java/aoc/App.java
+++ b/src/main/java/aoc/App.java
@@ -25,11 +25,7 @@ public class App {
     }
 
     private static List<String> loadInput(int day){
-        String paddedDay = String.valueOf(day);
-        if(day < 10) {
-            paddedDay = "0" + day;
-        }
-        String fileName = "day" + paddedDay + ".txt";
+        String fileName = String.format("day%02d.txt", day);
 
         try(BufferedReader r = new BufferedReader(new InputStreamReader(ClassLoader.getSystemResourceAsStream(fileName)))){
             return r.lines().collect(toList());

--- a/src/main/java/aoc/App.java
+++ b/src/main/java/aoc/App.java
@@ -3,59 +3,53 @@
  */
 package aoc;
 
-import aoc.day01.Day01;
+import org.reflections.Reflections;
 
-import java.io.*;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Set;
+import java.util.function.Function;
 
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 public class App {
-
-    private static final Map<Integer, Day> DAYS;
-
-    static {
-        DAYS = new HashMap<>();
-        DAYS.put(1, new Day01());
-    }
-
-    private static List<String> loadInput(int day){
-        String fileName = String.format("day%02d.txt", day);
-
-        InputStream inputForDay = ClassLoader.getSystemResourceAsStream(fileName);
-        if (Objects.isNull(inputForDay)) {
-            throw new IllegalArgumentException("Can’t find data for day using filename: " + fileName + ". Did you forget to put the file in the resources directory?");
-        }
-        try (BufferedReader r = new BufferedReader(new InputStreamReader(inputForDay))) {
-            return r.lines().collect(toList());
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
     public static void main(String[] args) {
-        int day = 1;
-        if(args.length != 0){
-            day = Integer.parseInt(args[0]);
+
+        Reflections reflections = new Reflections(Day.class.getPackageName());
+        Set<Day> daysToPrint = reflections.getSubTypesOf(Day.class).stream().map(initialiseInstance()).collect(toSet());
+        int specifiedPart = 1;
+        boolean dayWasSpecified = args.length != 0;
+        if (dayWasSpecified) {
+            int specifiedDay = Integer.parseInt(args[0]);
+            daysToPrint = daysToPrint.stream().filter(d -> d.dayNumber() == specifiedDay).collect(toSet());
+            if (args.length > 1) {
+                specifiedPart = Integer.parseInt(args[1]);
+            }
         }
 
-        int part = 1;
-        if(args.length > 1){
-            part = Integer.parseInt(args[1]);
+        for (Day currentDay : daysToPrint) {
+            if (dayWasSpecified) {
+                if (specifiedPart == 1) {
+                    currentDay.printPart1();
+                }
+                else {
+                    currentDay.printPart2();
+                }
+            }
+            else {
+                currentDay.printPart1();
+                currentDay.printPart2();
+            }
         }
+    }
 
-        List<String> input = loadInput(day);
-
-        String result;
-        if(part == 1) {
-            result = DAYS.get(day).part1(input);
-        } else {
-            result = DAYS.get(day).part2(input);
-        }
-
-        System.out.println(result);
+    private static Function<Class<? extends Day>, ? extends Day> initialiseInstance() {
+        return d -> {
+            try {
+                return d.getDeclaredConstructor().newInstance();
+            } catch (NoSuchMethodException | InvocationTargetException | InstantiationException |
+                     IllegalAccessException e) {
+                throw new RuntimeException("Encountered an issue attempting to create an instance of the current day class for child class: " + d.getName(), e);
+            }
+        };
     }
 }

--- a/src/main/java/aoc/Day.java
+++ b/src/main/java/aoc/Day.java
@@ -1,11 +1,64 @@
 package aoc;
 
+import java.io.*;
 import java.util.List;
+import java.util.Objects;
 
-public interface Day {
+import static java.util.stream.Collectors.toList;
 
-    String part1(List<String> input);
+public abstract class Day {
 
-    String part2(List<String> input);
+    protected static Day currentDay;
+    private final int dayNumber;
+
+    protected Day(int dayNumber) {
+        this.dayNumber = dayNumber;
+    }
+
+    public abstract String part1(List<String> input);
+
+    public String part1() {
+        return this.part1(loadInput());
+    }
+
+    public String part2() {
+        return this.part2(loadInput());
+    }
+
+    public abstract String part2(List<String> input);
+
+    private List<String> loadInput() {
+        String fileName = String.format("day%02d.txt", dayNumber);
+
+        InputStream inputForDay = ClassLoader.getSystemResourceAsStream(fileName);
+        if (Objects.isNull(inputForDay)) {
+            throw new IllegalArgumentException("Can’t find data for day using filename: " + fileName + ". Did you forget to put the file in the resources directory?");
+        }
+        try (BufferedReader r = new BufferedReader(new InputStreamReader(inputForDay))) {
+            return r.lines().collect(toList());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static void main(String[] unused) {
+        if (currentDay == null) {
+            throw new RuntimeException("You need to initialise currentDay in a static initialiser block in the child class");
+        }
+        currentDay.printPart1();
+        currentDay.printPart2();
+    }
+
+    void printPart2() {
+        System.out.println("Day " + this.dayNumber + ", Part 2: " + this.part2(this.loadInput()));
+    }
+
+    void printPart1() {
+        System.out.println("Day " + this.dayNumber + ", Part 1: " + this.part1(this.loadInput()));
+    }
+
+    public int dayNumber() {
+        return this.dayNumber;
+    }
 
 }

--- a/src/main/java/aoc/day01/Day01.java
+++ b/src/main/java/aoc/day01/Day01.java
@@ -4,7 +4,15 @@ import aoc.Day;
 
 import java.util.List;
 
-public class Day01 implements Day {
+public class Day01 extends Day {
+
+    static {
+        currentDay = new Day01();
+    }
+
+    public Day01() {
+        super(1);
+    }
 
     @Override
     public String part1(List<String> input) {


### PR DESCRIPTION
Thanks so much for this repo. I love having a handy starter project to get going on things like this. I’ve used your repo to pair with a bunch of people on AOC stuff to help teach. I find it can be a bit confusing to have to run `App` with parameters to specify which day to run, and sometimes we find ourselves running the wrong day as a result. We will often forget to add the day to the static collection.

I thought it would be good if you could actually run the day that you're working on without leaving the file. When we start a pairing session, we often won't have worked on the code for a week, and forget how to actually run it. I felt like the idea of each day being runnable on its own as it seems a bit more intuitive.

I'm not a big fan of how I've had to achieve this, as I'm not generally a fan of inheritance. I also think having to create a static instance of the day in a static initialiser block is a bit unusual, but it was the nicest way I could find to dynamically get access to an instance of the class from a static context. The other possibility was interrogating the current thread’s call stack but that seemed even stranger and more prone to failure.

I've tried to structure the commits so that the order makes some sense. ~~The last commit is worth looking at in isolation as it introduces a dependency in order to have an easy way to run each of the days. One by one. Let me know what you think about that. I'm happy to take that one out and resubmit the request if that works for you.~~ (the struck out text is no longer relevant—while updating the README I realised I needed to retain the existing App.java functionality so that the instructions to print the solutions still worked)